### PR TITLE
add optional support of id string schema validation

### DIFF
--- a/puff.py
+++ b/puff.py
@@ -19,6 +19,9 @@ _BASE_SCHEMA = {
                 'type': {
                     'type': 'string'
                 },
+                'id': {
+                    'type': 'string'
+                },
                 'attributes': {
                     'type': 'object',
                     'properties': None,


### PR DESCRIPTION
This patch provides support for schema validation of the `id` that is optional in jsonapi spec. 
Since this is optional it will not enforce that an `id` be in every object sent, but if it does exist it should be a `string` as indicated by jsonapi. 